### PR TITLE
Add exception for kubernetes_cluster_role's non_resource_urls rule field

### DIFF
--- a/name_mapper.go
+++ b/name_mapper.go
@@ -62,19 +62,21 @@ func normalizeTerraformName(s string, toSingular bool, path string) string {
 	case "DaemonSet":
 		return "daemonset"
 
+	case "nonResourceURLs":
+		if strings.Contains(path, "role.rule.") {
+			return "non_resource_urls"
+		}
+
 	case "updateStrategy":
 		if !strings.Contains(path, "stateful") {
 			return "strategy"
 		}
-
-		fallthrough
-
-	default:
-		if toSingular {
-			s = inflection.Singular(s)
-		}
-		s = strcase.ToSnake(s)
 	}
+
+	if toSingular {
+		s = inflection.Singular(s)
+	}
+	s = strcase.ToSnake(s)
 
 	return s
 }

--- a/name_mapper_test.go
+++ b/name_mapper_test.go
@@ -31,6 +31,28 @@ func TestToTerraformAttributeName(t *testing.T) {
 			},
 			"replicas",
 		},
+		{
+			"non_resource_urls",
+			args{
+				&reflect.StructField{
+					Name: "NonResourceURLs",
+					Tag:  `json:"nonResourceURLs,omitempty" protobuf:"bytes,5,rep,name=nonResourceURLs"`,
+				},
+				"cluster_role.rule.",
+			},
+			"non_resource_urls",
+		},
+		{
+			"non_resource_urls",
+			args{
+				&reflect.StructField{
+					Name: "NonResourceURLs",
+					Tag:  `json:"nonResourceURLs,omitempty" protobuf:"bytes,5,rep,name=nonResourceURLs"`,
+				},
+				"role.rule.",
+			},
+			"non_resource_urls",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -164,6 +186,24 @@ func Test_normalizeTerraformName(t *testing.T) {
 				"",
 			},
 			"metadata",
+		},
+		{
+			"non_resource_urls",
+			args{
+				"nonResourceURLs",
+				false,
+				"cluster_role.rule.",
+			},
+			"non_resource_urls",
+		},
+		{
+			"non_resource_urls",
+			args{
+				"nonResourceURLs",
+				false,
+				"role.rule.",
+			},
+			"non_resource_urls",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
This PR adds an exception for the conversion of [kubernetes' `nonResourceURLs` ClusterRole & Role rule field](https://github.com/kubernetes/api/blob/kubernetes-1.14.0/rbac/v1/types.go#L68) into the [terraform provider's `non_resource_urls` casing](https://github.com/terraform-providers/terraform-provider-kubernetes/blob/v1.5.2/kubernetes/schema_rbac.go#L68).

Without this change, the field is converted as `non_resource_ur_ls`.

I believe the underlying issue is that converting plain strings poses an issue with plural acronyms for which case is not explicitly defined:

> Go field names must be CamelCase. JSON field names must be camelCase. Other than capitalization of the initial letter, the two should almost always match. No underscores nor dashes in either.
> [...]
> Acronyms should similarly only be used when extremely commonly known. All letters in the acronym should have the same case, using the appropriate case for the situation. For example, at the beginning of a field name, the acronym should be all lowercase, such as "httpGet". Where used as a constant, all letters should be uppercase, such as "TCP" or "UDP".

cf. https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#naming-conventions

I believe the conversion process should take the source casing into account (e.g. from Camel Case to Snake Case), or better yet have some pivot format defining at the very least what's a word, an acronym, and if it's plural or singular. I did not find any Go implementation doing that yet.