### PR TITLE
Fix: reading multiple yaml from nested dir

### DIFF
--- a/main.go
+++ b/main.go
@@ -72,7 +72,7 @@ func main() {
 
 	objs := readInput()
 
-	log.Debug().Int("count", len(objs)).Msg("read objects from input")
+	log.Debug().Msgf("read %d objects from input", len(objs))
 
 	w, closer := setupOutput()
 	defer closer()
@@ -154,6 +154,7 @@ func readFilesInput() []runtime.Object {
 	}
 
 	readFile := func(fileName string) {
+		log.Debug().Msgf("reading file: %s", fileName)
 		content, err := ioutil.ReadFile(fileName)
 		if err != nil {
 			log.Fatal().Err(err)
@@ -169,6 +170,8 @@ func readFilesInput() []runtime.Object {
 
 	if fs.Mode().IsDir() {
 		// read directory
+		log.Debug().Msgf("reading directory: %s", input)
+
 		dirContents, err := file.Readdirnames(0)
 		if err != nil {
 			log.Fatal().Err(err)
@@ -176,7 +179,7 @@ func readFilesInput() []runtime.Object {
 
 		for _, f := range dirContents {
 			if strings.HasSuffix(f, ".yml") || strings.HasSuffix(f, ".yaml") {
-				readFile(filepath.Join(fs.Name(), f))
+				readFile(filepath.Join(input, f))
 			}
 		}
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"testing"
+)
+
+func Test_readFilesInput(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        string
+		wantObjCount int
+	}{
+		{
+			"test-fixtures/service.yaml",
+			"test-fixtures/service.yaml",
+			1,
+		},
+		{
+			"test-fixtures",
+			"test-fixtures",
+			11,
+		},
+		{
+			"test-fixtures/",
+			"test-fixtures/",
+			11,
+		},
+		{
+			"test-fixtures/nested/server-clusterrole.yaml",
+			"test-fixtures/nested/server-clusterrole.yaml",
+			1,
+		},
+		{
+			"test-fixtures/nested/",
+			"test-fixtures/nested/",
+			4,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input = tt.input
+			if got := readFilesInput(); len(got) != tt.wantObjCount {
+				t.Errorf("readFilesInput() object Count = %d, want %d", len(got), tt.wantObjCount)
+			}
+		})
+	}
+}

--- a/test-fixtures/nested/kube-state-metrics-serviceaccount.yaml
+++ b/test-fixtures/nested/kube-state-metrics-serviceaccount.yaml
@@ -1,0 +1,13 @@
+---
+# Source: prometheus/templates/kube-state-metrics-serviceaccount.yaml
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: prometheus
+    chart: prometheus-5.5.3
+    component: "kube-state-metrics"
+    heritage: Tiller
+    release: RELEASE-NAME
+  name: RELEASE-NAME-prometheus-kube-state-metrics

--- a/test-fixtures/nested/server-clusterrole.yaml
+++ b/test-fixtures/nested/server-clusterrole.yaml
@@ -1,0 +1,46 @@
+---
+# Source: prometheus/templates/server-clusterrole.yaml
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    app: prometheus
+    chart: prometheus-5.5.3
+    component: "server"
+    heritage: Tiller
+    release: RELEASE-NAME
+  name: RELEASE-NAME-prometheus-server
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+      - nodes/proxy
+      - services
+      - endpoints
+      - pods
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+  - apiGroups:
+      - "extensions"
+    resources:
+      - ingresses/status
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - nonResourceURLs:
+      - "/metrics"
+    verbs:
+      - get

--- a/test-fixtures/nested/server-clusterrolebinding.yaml
+++ b/test-fixtures/nested/server-clusterrolebinding.yaml
@@ -1,0 +1,21 @@
+---
+# Source: prometheus/templates/server-clusterrolebinding.yaml
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: prometheus
+    chart: prometheus-5.5.3
+    component: "server"
+    heritage: Tiller
+    release: RELEASE-NAME
+  name: RELEASE-NAME-prometheus-server
+subjects:
+  - kind: ServiceAccount
+    name: RELEASE-NAME-prometheus-server
+    namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: RELEASE-NAME-prometheus-server

--- a/test-fixtures/nested/server-pvc.yaml
+++ b/test-fixtures/nested/server-pvc.yaml
@@ -1,0 +1,19 @@
+---
+# Source: prometheus/templates/server-pvc.yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app: prometheus
+    chart: prometheus-5.5.3
+    component: "server"
+    heritage: Tiller
+    release: RELEASE-NAME
+  name: RELEASE-NAME-prometheus-server
+spec:
+  accessModes:
+    - ReadWriteOnce
+    
+  resources:
+    requests:
+      storage: "8Gi"

--- a/test-fixtures/service.yaml
+++ b/test-fixtures/service.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/yaml_parser.go
+++ b/yaml_parser.go
@@ -6,6 +6,7 @@ import (
 	"io"
 
 	multierror "github.com/hashicorp/go-multierror"
+	"github.com/rs/zerolog/log"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -24,11 +25,13 @@ func parseK8SYAML(in io.Reader) ([]runtime.Object, error) {
 			break
 		}
 		if err != nil {
+			log.Error().Err(err)
 			result = multierror.Append(result, err)
 		}
 		d := scheme.Codecs.UniversalDeserializer()
 		obj, _, err := d.Decode(doc, nil, nil)
 		if err != nil {
+			log.Error().Err(err)
 			wrapped := fmt.Errorf("could not decode yaml object #%d: %s", i, err)
 			result = multierror.Append(result, wrapped)
 		}


### PR DESCRIPTION
This fixes an issue where k2tf would fail to read multiple files from a nest subdirectory.
i.e.
The following works:
`k2tf -f directory/`

The following does not work, will fail to read any objects:
`k2tf -f directory/subdirectory/`

Fixes #7