### PR TITLE
Format HCL on output.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/sl1pm4t/k2tf
 require (
 	github.com/googleapis/gax-go v2.0.2+incompatible // indirect
 	github.com/hashicorp/go-multierror v1.0.0
+	github.com/hashicorp/hcl v1.0.0
 	github.com/hashicorp/hcl2 v0.0.0-20190416162332-2c5a4b7d729a
 	github.com/hashicorp/terraform v0.12.0-alpha4.0.20190417210818-177a7afb781f
 	github.com/iancoleman/strcase v0.0.0-20180726023541-3605ed457bf7

--- a/hcl_writer_test.go
+++ b/hcl_writer_test.go
@@ -145,7 +145,7 @@ func validateTerraformConfig(t *testing.T, resourceType string, cfg *config.RawC
 
 func parseResourceHCL(t *testing.T, hcl []byte) *config.RawConfig {
 	// write HCL to temp location where Terraform can load it
-	tmpDir, err := ioutil.TempDir("", "ky2tf")
+	tmpDir, err := ioutil.TempDir("", "k2tf")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/log.go
+++ b/log.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"fmt"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"os"
+	"strings"
+)
+
+func setupLogOutput() {
+	// Setup Console Output
+	output := zerolog.ConsoleWriter{Out: os.Stderr}
+	output.FormatLevel = formatLevel(noColor)
+	output.FormatMessage = func(i interface{}) string {
+		return fmt.Sprintf("| %-60s ", i)
+	}
+	log.Logger = log.Output(output)
+
+	// Default level for this example is info, unless debug flag is present
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
+	if debug {
+		zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	}
+}
+
+func formatLevel(noColor bool) zerolog.Formatter {
+	return func(i interface{}) string {
+		var l string
+		if ll, ok := i.(string); ok {
+			switch ll {
+			case "debug":
+				l = colorize("Debug", colorYellow, noColor)
+			case "info":
+				l = colorize("Info", colorGreen, noColor)
+			case "warn":
+				l = colorize("Warn", colorRed, noColor)
+			case "error":
+				l = colorize(colorize("Error", colorRed, noColor), colorBold, noColor)
+			case "fatal":
+				l = colorize(colorize("Fatal", colorRed, noColor), colorBold, noColor)
+			case "panic":
+				l = colorize(colorize("Panic", colorRed, noColor), colorBold, noColor)
+			default:
+				l = colorize("???", colorBold, noColor)
+			}
+		} else {
+			l = strings.ToUpper(fmt.Sprintf("%s", i))[0:3]
+		}
+		return l
+	}
+}
+
+// colorize returns the string s wrapped in ANSI code c, unless disabled is true.
+func colorize(s interface{}, c int, disabled bool) string {
+	if disabled {
+		return fmt.Sprintf("%s", s)
+	}
+	return fmt.Sprintf("\x1b[%dm%v\x1b[0m", c, s)
+}
+
+const (
+	colorBlack = iota + 30
+	colorRed
+	colorGreen
+	colorYellow
+	colorBlue
+	colorMagenta
+	colorCyan
+	colorWhite
+
+	colorBold     = 1
+	colorDarkGray = 90
+)


### PR DESCRIPTION
Also adds a flag to use TF 0.12 formatter.
The TF 0.12 formatter is less aggressive than earlier versions, so default is to use TF 0.11 formatter for now until TF 0.12 goes GA.
See - https://github.com/hashicorp/terraform/issues/20910#issuecomment-479946978

This change also moves logger setup into it’s own file.

Closes #9 