### PR TITLE
Skip unsupported API objects

### DIFF
--- a/input_test.go
+++ b/input_test.go
@@ -18,12 +18,12 @@ func Test_readFilesInput(t *testing.T) {
 		{
 			"test-fixtures",
 			"test-fixtures",
-			12,
+			13,
 		},
 		{
 			"test-fixtures/",
 			"test-fixtures/",
-			12,
+			13,
 		},
 		{
 			"test-fixtures/nested/server-clusterrole.yaml",

--- a/main.go
+++ b/main.go
@@ -56,16 +56,20 @@ func main() {
 	defer closer()
 
 	for i, obj := range objs {
-		f := hclwrite.NewEmptyFile()
-		err := WriteObject(obj, f.Body())
-		if err != nil {
-			log.Error().Int("obj#", i).Err(err).Msg("error writing object")
+		if IsKubernetesKindSupported(obj) {
+			f := hclwrite.NewEmptyFile()
+			err := WriteObject(obj, f.Body())
+			if err != nil {
+				log.Error().Int("obj#", i).Err(err).Msg("error writing object")
+			}
+
+			formatted := formatObject(f.Bytes())
+
+			fmt.Fprint(w, string(formatted))
+			fmt.Fprintln(w)
+		} else {
+			log.Warn().Str("kind", obj.GetObjectKind().GroupVersionKind().Kind).Msg("skipping API object, kind not supported by Terraform provider.")
 		}
-
-		formatted := formatObject(f.Bytes())
-
-		fmt.Fprint(w, string(formatted))
-		fmt.Fprintln(w)
 	}
 }
 

--- a/schema.go
+++ b/schema.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"k8s.io/apimachinery/pkg/runtime"
 	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -20,6 +21,18 @@ func ResourceSchema(name string) *schema.Resource {
 	}
 
 	return nil
+}
+
+// IsKubernetesKindSupported returns true if a matching resource is found in the Terraform provider
+func IsKubernetesKindSupported(obj runtime.Object) bool {
+	name := ToTerraformResourceType(obj)
+
+	res := ResourceSchema(name)
+	if res != nil {
+		return true
+	}
+
+	return false
 }
 
 // IsAttributeSupported scans the Terraform resource to determine if the named

--- a/test-fixtures/podDisruptionBudget.yaml
+++ b/test-fixtures/podDisruptionBudget.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: zk-pdb
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: zookeeper


### PR DESCRIPTION
This change shortcuts processing of unsupported API objects.
Prior to this fix the tool would create empty resource blocks for API object types that were not supported by Terraform provider. Now it prints a warning, and doesn't output any HCL for the unsupported resource type.