### PR TITLE
Wrap map keys in quotes if key contains dot ’.’

### DIFF
--- a/name_mapper.go
+++ b/name_mapper.go
@@ -139,10 +139,10 @@ func ToTerraformResourceName(obj runtime.Object) string {
 // NormalizeTerraformMapKey converts Map keys to a form suitable for Terraform
 // HCL
 //
-// e.g. map keys that include certain characters ( '/' ) will be wrapped in
+// e.g. map keys that include certain characters ( '/', '.' ) will be wrapped in
 // double quotes.
 func NormalizeTerraformMapKey(s string) string {
-	if strings.Contains(s, "/") {
+	if strings.Contains(s, "/") || strings.Contains(s, ".") {
 		return fmt.Sprintf(`"%s"`, s)
 	}
 	return s

--- a/name_mapper_test.go
+++ b/name_mapper_test.go
@@ -277,3 +277,25 @@ func TestToTerraformResourceType(t *testing.T) {
 		})
 	}
 }
+
+func TestNormalizeTerraformMapKey(t *testing.T) {
+	type args struct {
+		s string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{"slash", args{"kubernetes/foo"}, `"kubernetes/foo"`},
+		{"dot", args{"kubernetes.io"}, `"kubernetes.io"`},
+		{"no_change", args{"kubernetes"}, `kubernetes`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NormalizeTerraformMapKey(tt.args.s); got != tt.want {
+				t.Errorf("NormalizeTerraformMapKey() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Map keys with a dot in the name should be wrapped in quotes to avoid a TF syntax error.