### PR TITLE
Fix(name mapper): don't convert "tls" to singular

### DIFF
--- a/hcl_writer.go
+++ b/hcl_writer.go
@@ -22,7 +22,7 @@ import (
 func WriteObject(obj runtime.Object, dst *hclwrite.Body) (int, error) {
 	w, err := NewObjectWalker(obj, dst)
 	if err != nil {
-		return w.warnCount, err
+		return 0, err
 	}
 	reflectwalk.Walk(obj, w)
 

--- a/hcl_writer_test.go
+++ b/hcl_writer_test.go
@@ -72,6 +72,11 @@ func TestWriteObject(t *testing.T) {
 			0,
 		},
 		{
+			"ingress",
+			"kubernetes_ingress",
+			0,
+		},
+		{
 			"namespace",
 			"kubernetes_namespace",
 			0,
@@ -177,7 +182,10 @@ func parseResourceHCL(t *testing.T, hcl []byte) *config.RawConfig {
 	defer os.RemoveAll(tmpDir)
 
 	// Write the file
-	ioutil.WriteFile(filepath.Join(tmpDir, "hcl.tf"), hcl, os.ModePerm)
+	err = ioutil.WriteFile(filepath.Join(tmpDir, "hcl.tf"), hcl, os.ModePerm)
+	if err != nil {
+		t.Fatalf("test setup error: %v", err)
+	}
 
 	// use terraform to load config from tmp dir
 	cfg, err := config.LoadDir(tmpDir)
@@ -197,7 +205,7 @@ func testParseK8SYAML(t *testing.T, s string) runtime.Object {
 	r := strings.NewReader(s)
 	objs, err := parseK8SYAML(r)
 	if err != nil {
-		t.Error("testParseK8SYAML err: ", err)
+		t.Fatalf("test setup error, could not parse test YAML: %v", err)
 		return nil
 	}
 	return objs[0]

--- a/input_test.go
+++ b/input_test.go
@@ -18,12 +18,12 @@ func Test_readFilesInput(t *testing.T) {
 		{
 			"test-fixtures",
 			"test-fixtures",
-			15,
+			16,
 		},
 		{
 			"test-fixtures/",
 			"test-fixtures/",
-			15,
+			16,
 		},
 		{
 			"test-fixtures/nested/server-clusterrole.yaml",

--- a/name_mapper.go
+++ b/name_mapper.go
@@ -24,6 +24,7 @@ func init() {
 	inflection.AddUncountable("data")
 	inflection.AddUncountable("metadata")
 	inflection.AddUncountable("items")
+	inflection.AddUncountable("tls")
 }
 
 // ToTerraformAttributeName takes the reflect.StructField data of a Kubernetes object attribute

--- a/test-fixtures/ingress.tf.golden
+++ b/test-fixtures/ingress.tf.golden
@@ -1,0 +1,25 @@
+resource "kubernetes_ingress" "tls_example_ingress" {
+  metadata {
+    name = "tls-example-ingress"
+  }
+  spec {
+    rule {
+      host = "sslexample.foo.com"
+      http {
+        path {
+          path = "/"
+          backend {
+            service_name = "service1"
+            service_port = "80"
+          }
+        }
+      }
+    }
+    tls {
+        hosts = [
+            "sslexample.foo.com",
+        ]
+        secret_name = "testsecret-tls"
+    }
+  }
+}

--- a/test-fixtures/ingress.yaml
+++ b/test-fixtures/ingress.yaml
@@ -1,0 +1,17 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: tls-example-ingress
+spec:
+  tls:
+    - hosts:
+        - sslexample.foo.com
+      secretName: testsecret-tls
+  rules:
+    - host: sslexample.foo.com
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: service1
+              servicePort: 80


### PR DESCRIPTION
Fixes #21

Fixes an issue with `ingress` resources, where the `tls` block name would be converted to `tl` (singular) and then could not be found in the TFK resource schema.