### PR TITLE
add Msg to Fatal logs (or it won't exit)

### DIFF
--- a/input.go
+++ b/input.go
@@ -3,11 +3,12 @@ package main
 import (
 	"bufio"
 	"bytes"
-	"github.com/sl1pm4t/k2tf/pkg/k8sparser"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/sl1pm4t/k2tf/pkg/k8sparser"
 
 	"github.com/rs/zerolog/log"
 	corev1 "k8s.io/api/core/v1"
@@ -35,8 +36,9 @@ func readStdinInput() []runtime.Object {
 
 	reader := bufio.NewReader(os.Stdin)
 	parsed, err := k8sparser.ParseYAML(reader)
+
 	if err != nil {
-		log.Fatal().Err(err)
+		log.Fatal().Err(err).Msg("Could not parse stdin")
 	}
 
 	for _, obj := range parsed {
@@ -70,25 +72,25 @@ func readFilesInput() []runtime.Object {
 
 	file, err := os.Open(input)
 	if err != nil {
-		log.Fatal().Err(err)
+		log.Fatal().Err(err).Msg("")
 	}
 
 	fs, err := file.Stat()
 	if err != nil {
-		log.Fatal().Err(err)
+		log.Fatal().Err(err).Msg("")
 	}
 
 	readFile := func(fileName string) {
 		log.Debug().Msgf("reading file: %s", fileName)
 		content, err := ioutil.ReadFile(fileName)
 		if err != nil {
-			log.Fatal().Err(err)
+			log.Fatal().Err(err).Msg("")
 		}
 
 		r := bytes.NewReader(content)
 		obj, err := k8sparser.ParseYAML(r)
 		if err != nil {
-			log.Fatal().Err(err)
+			log.Fatal().Err(err).Msg("")
 		}
 		objs = append(objs, obj...)
 	}
@@ -99,7 +101,7 @@ func readFilesInput() []runtime.Object {
 
 		dirContents, err := file.Readdirnames(0)
 		if err != nil {
-			log.Fatal().Err(err)
+			log.Fatal().Err(err).Msg("")
 		}
 
 		for _, f := range dirContents {

--- a/output.go
+++ b/output.go
@@ -26,13 +26,13 @@ func setupOutput() (io.Writer, CloseFunc) {
 		f, err := os.OpenFile(output, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
 		w = f
 		if err != nil {
-			log.Fatal().Err(err)
+			log.Fatal().Err(err).Msg("")
 		}
 		log.Debug().Str("file", output).Msg("opened file")
 
 		closeFn = func() {
 			if err := f.Close(); err != nil {
-				log.Fatal().Err(err)
+				log.Fatal().Err(err).Msg("")
 			}
 			log.Debug().Str("file", output).Msg("closed output file")
 		}


### PR DESCRIPTION
Hi, thanks for the awesome tool!

As the title says:

> Fatal starts a new message with fatal level. The os.Exit(1) function is called by the Msg method, which terminates the program immediately.
>
> You must call Msg on the returned event in order to send the event.

https://godoc.org/github.com/rs/zerolog#Logger.Fatal