### PR TITLE
fix: TF0.12 more picky about map syntax

### DIFF
--- a/hcl_block.go
+++ b/hcl_block.go
@@ -38,6 +38,23 @@ type hclBlock struct {
 	// inlined flags whether this block is supported in the Terraform Provider schema
 	// Unsupported blocks will be excluded from HCL rendering
 	unsupported bool
+
+	// isMap flags whether the output of this block will be map syntax rather than a sub-block
+	// e.g.
+	// mapName = {
+	//   key = "value"
+	// }
+	// vs.
+	// mapName {
+	//   key = "value"
+	// }
+	// In TF0.12.0 Schema attributes of type schema.TypeMap must be written with the former syntax, and sub-blocks
+	// most use the latter.
+	// However, there are some cases where a Golang map on the Kubernetes object side is not defined
+	// as schema.TypeMap on the Terraform side (e.g. Container.Limits) so isMap is used to track how this block
+	// should be outputted.
+	isMap       bool
+	hclMap      map[string]cty.Value
 }
 
 // A child block is adding a sub-block, write HCL to:
@@ -58,8 +75,14 @@ func (b *hclBlock) AppendBlock(hcl *hclwrite.Block) {
 // - this hclBlock's hcl Body if this block is not inlined
 // - parent's HCL body if this block is "inlined"
 func (b *hclBlock) SetAttributeValue(name string, val cty.Value) {
+	if b.isMap {
+		if b.hclMap == nil {
+			b.hclMap = map[string]cty.Value{name: val}
+		} else {
+			b.hclMap[name] = val
+		}
 
-	if includeUnsupported || tfkschema.IsAttributeSupported(b.FullSchemaName()+"."+name) {
+	} else if includeUnsupported || tfkschema.IsAttributeSupported(b.FullSchemaName()+"."+name) {
 		if b.inlined {
 			// append to parent
 			b.parent.SetAttributeValue(name, val)

--- a/test-fixtures/basicDeployment.tf.golden
+++ b/test-fixtures/basicDeployment.tf.golden
@@ -2,23 +2,23 @@ resource "kubernetes_deployment" "baz_app" {
   metadata {
     name      = "baz-app"
     namespace = "bat"
-    annotations {
+    annotations = {
       foo = "fam"
     }
   }
   spec {
     replicas = 2
     selector {
-      match_labels {
+      match_labels = {
         app = "nginx"
       }
     }
     template {
       metadata {
-        labels {
+        labels = {
           app = "nginx"
         }
-        annotations {
+        annotations = {
           foo = "fam"
         }
       }

--- a/test-fixtures/configMap.tf.golden
+++ b/test-fixtures/configMap.tf.golden
@@ -2,12 +2,12 @@ resource "kubernetes_config_map" "foo_config_map" {
   metadata {
     name      = "foo-config-map"
     namespace = "bar"
-    labels {
+    labels = {
       lbl1 = "somevalue"
       lbl2 = "another"
     }
   }
-  data {
+  data = {
     item1 = "wow"
     item2 = "wee"
   }

--- a/test-fixtures/daemonset.tf.golden
+++ b/test-fixtures/daemonset.tf.golden
@@ -2,19 +2,19 @@ resource "kubernetes_daemonset" "terraform_example" {
   metadata {
     name      = "terraform-example"
     namespace = "something"
-    labels {
+    labels = {
       test = "MyExampleApp"
     }
   }
   spec {
     selector {
-      match_labels {
+      match_labels = {
         test = "MyExampleApp"
       }
     }
     template {
       metadata {
-        labels {
+        labels = {
           test = "MyExampleApp"
         }
       }

--- a/test-fixtures/deployment.tf.golden
+++ b/test-fixtures/deployment.tf.golden
@@ -2,23 +2,23 @@ resource "kubernetes_deployment" "backend_api" {
   metadata {
     name      = "backend-api"
     namespace = "default"
-    labels {
+    labels = {
       app = "backend-api"
     }
   }
   spec {
     replicas = 4
     selector {
-      match_labels {
+      match_labels = {
         app = "backend-api"
       }
     }
     template {
       metadata {
-        labels {
+        labels = {
           app = "backend-api"
         }
-        annotations {
+        annotations = {
           "prometheus.io/port"   = "8080"
           "prometheus.io/scheme" = "http"
           "prometheus.io/scrape" = "true"

--- a/test-fixtures/deployment2Containers.tf.golden
+++ b/test-fixtures/deployment2Containers.tf.golden
@@ -4,13 +4,13 @@ resource "kubernetes_deployment" "backend_api" {
   }
   spec {
     selector {
-      match_labels {
+      match_labels = {
         app = "backend-api"
       }
     }
     template {
       metadata {
-        labels {
+        labels = {
           app = "backend-api"
         }
       }

--- a/test-fixtures/endpoints.tf.golden
+++ b/test-fixtures/endpoints.tf.golden
@@ -2,7 +2,7 @@ resource "kubernetes_endpoints" "backend" {
   metadata {
     name      = "backend"
     namespace = "default"
-    annotations {
+    annotations = {
       "alpha.istio.io/kubernetes-serviceaccounts" = "default"
     }
   }

--- a/test-fixtures/namespace.tf.golden
+++ b/test-fixtures/namespace.tf.golden
@@ -1,7 +1,7 @@
 resource "kubernetes_namespace" "cert_manager" {
   metadata {
     name = "cert-manager"
-    labels {
+    labels = {
       "certmanager.k8s.io/disable-validation" = "true"
     }
   }

--- a/test-fixtures/namespace_w_spec.tf.golden
+++ b/test-fixtures/namespace_w_spec.tf.golden
@@ -1,7 +1,7 @@
 resource "kubernetes_namespace" "cert_manager" {
   metadata {
     name = "cert-manager"
-    labels {
+    labels = {
       "certmanager.k8s.io/disable-validation" = "true"
     }
   }

--- a/test-fixtures/podNodeExporter.tf.golden
+++ b/test-fixtures/podNodeExporter.tf.golden
@@ -3,12 +3,12 @@ resource "kubernetes_pod" "node_exporter_7fth_7" {
     name          = "node-exporter-7fth7"
     generate_name = "node-exporter-"
     namespace     = "prometheus"
-    labels {
+    labels = {
       controller-revision-hash = "2418008739"
       name                     = "node-exporter"
       pod-template-generation  = "1"
     }
-    annotations {
+    annotations = {
       "prometheus.io/scrape" = "true"
       "prometheus.io/port"   = "9100"
       "prometheus.io/scheme" = "http"

--- a/test-fixtures/service.tf.golden
+++ b/test-fixtures/service.tf.golden
@@ -1,7 +1,7 @@
 resource "kubernetes_service" "nginx" {
   metadata {
     name = "nginx"
-    labels {
+    labels = {
       app = "nginx"
     }
   }

--- a/test-fixtures/statefulSet.tf.golden
+++ b/test-fixtures/statefulSet.tf.golden
@@ -1,20 +1,20 @@
 resource "kubernetes_stateful_set" "web" {
   metadata {
     name = "web"
-    labels {
+    labels = {
       app = "nginx"
     }
   }
   spec {
     replicas = 14
     selector {
-      match_labels {
+      match_labels = {
         app = "nginx"
       }
     }
     template {
       metadata {
-        labels {
+        labels = {
           app = "nginx"
         }
       }
@@ -40,7 +40,7 @@ resource "kubernetes_stateful_set" "web" {
       spec {
         access_modes = ["ReadWriteOnce"]
         resources {
-          requests {
+          requests = {
             storage = "1Gi"
           }
         }


### PR DESCRIPTION
With TF 0.12.3 maps should be output as HCL maps (equals "=" before opening braces) rather an sub-blocks. However some maps from the Kubernetes Objects are not typed as Maps on the Terraform side, so some special handling is required to support these cases.

Fixes #30