### PR TITLE
Skip CRD resources when processing multiple YAMLs

### DIFF
--- a/input.go
+++ b/input.go
@@ -84,13 +84,13 @@ func readFilesInput() []runtime.Object {
 		log.Debug().Msgf("reading file: %s", fileName)
 		content, err := ioutil.ReadFile(fileName)
 		if err != nil {
-			log.Fatal().Err(err).Msg("")
+			log.Fatal().Err(err).Msg("could not read file")
 		}
 
 		r := bytes.NewReader(content)
 		obj, err := k8sparser.ParseYAML(r)
 		if err != nil {
-			log.Fatal().Err(err).Msg("")
+			log.Warn().Err(err).Msg("could not parse file")
 		}
 		objs = append(objs, obj...)
 	}

--- a/pkg/k8sparser/yaml_parser.go
+++ b/pkg/k8sparser/yaml_parser.go
@@ -35,7 +35,7 @@ func ParseYAML(in io.Reader) ([]runtime.Object, error) {
 		obj, _, err := d.Decode(doc, nil, nil)
 		if err != nil {
 			log.Error().Err(err)
-			wrapped := fmt.Errorf("could not decode yaml object with main scheme #%d: %s", i, err)
+			wrapped := fmt.Errorf("could not decode yaml object with main scheme #%d: %v", i, err)
 
 			// Fallback on aggregator decoder
 			d = aggregator_scheme.Codecs.UniversalDeserializer()
@@ -45,7 +45,7 @@ func ParseYAML(in io.Reader) ([]runtime.Object, error) {
 
 				// Push both errors
 				result = multierror.Append(result, wrapped)
-				wrapped = fmt.Errorf("could not decode yaml object with aggregator scheme #%d: %s", i, err)
+				wrapped = fmt.Errorf("could not decode yaml object with aggregator scheme #%d: %v", i, err)
 				result = multierror.Append(result, wrapped)
 			}
 		}

--- a/test-fixtures/multiple_wCRD/crd.yaml
+++ b/test-fixtures/multiple_wCRD/crd.yaml
@@ -1,0 +1,40 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: crontabs.stable.example.com
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: stable.example.com
+  # list of versions supported by this CustomResourceDefinition
+  versions:
+    - name: v1
+      # Each version can be enabled/disabled by Served flag.
+      served: true
+      # One and only one version must be marked as the storage version.
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                cronSpec:
+                  type: string
+                image:
+                  type: string
+                replicas:
+                  type: integer
+  # either Namespaced or Cluster
+  scope: Namespaced
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: crontabs
+    # singular name to be used as an alias on the CLI and for display
+    singular: crontab
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: CronTab
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+      - ct

--- a/test-fixtures/multiple_wCRD/pod.yaml
+++ b/test-fixtures/multiple_wCRD/pod.yaml
@@ -1,0 +1,16 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: poddy
+  annotations:
+    foo: fam
+  labels:
+    app: nginx
+spec:
+  containers:
+    - name: nginx
+      image: nginx
+      args: ["--debug", "--test"]
+      ports:
+        - port: 80
+          containerPort: 80


### PR DESCRIPTION
This is a bandaid for now. Simply log  YAML parsing errors as WARN level instead of Fatal so additional files can be processed.

Fixes #46 