### PR TITLE
update service.tf.golden per latest k2tf conversion

### DIFF
--- a/test-fixtures/service.tf.golden
+++ b/test-fixtures/service.tf.golden
@@ -1,15 +1,24 @@
 resource "kubernetes_service" "nginx" {
   metadata {
-    name   = "nginx"
-    labels = { app = "nginx" }
+    name = "nginx"
+
+    labels = {
+      app = "nginx"
+    }
   }
+
   spec {
     port {
       name = "web"
       port = 80
     }
-    selector     = { app = "nginx" }
+
+    selector = {
+      app = "nginx"
+    }
+
     cluster_ip   = "None"
     external_ips = ["192.168.10.2"]
   }
 }
+


### PR DESCRIPTION
It looks like the golden file does not match with what k2tf generated, thus, refresh the `service.tf.golden` file

---

relates to https://github.com/Homebrew/homebrew-core/pull/86402