### PR TITLE
Fix ClusterRole aggregation_rule.cluster_role_selector] not found

### DIFF
--- a/hcl_writer_test.go
+++ b/hcl_writer_test.go
@@ -138,6 +138,11 @@ func TestWriteObject(t *testing.T) {
 			"kubernetes_certificate_signing_request",
 			0,
 		},
+		{
+			"clusterRole",
+			"kubernetes_cluster_role",
+			0,
+		},
 	}
 
 	for _, tt := range tests {

--- a/input_test.go
+++ b/input_test.go
@@ -18,12 +18,12 @@ func Test_readFilesInput(t *testing.T) {
 		{
 			"test-fixtures",
 			"test-fixtures",
-			21,
+			22,
 		},
 		{
 			"test-fixtures/",
 			"test-fixtures/",
-			21,
+			22,
 		},
 		{
 			"test-fixtures/nested/server-clusterrole.yaml",

--- a/pkg/tfkschema/name_mapper.go
+++ b/pkg/tfkschema/name_mapper.go
@@ -23,6 +23,7 @@ func init() {
 	inflection.AddSingular("requests", "requests")
 	inflection.AddSingular("imagePullSecrets", "imagePullSecrets")
 	inflection.AddSingular("capabilities", "capabilities")
+	inflection.AddSingular("ClusterRoleSelectors", "ClusterRoleSelectors")
 
 	inflection.AddUncountable("data")
 	inflection.AddUncountable("metadata")

--- a/test-fixtures/clusterRole.tf.golden
+++ b/test-fixtures/clusterRole.tf.golden
@@ -1,0 +1,10 @@
+resource "kubernetes_cluster_role" "monitoring" {
+  metadata {
+    name = "monitoring"
+  }
+  aggregation_rule {
+    cluster_role_selectors {
+      match_labels = { "rbac.example.com/aggregate-to-monitoring" = "true" }
+    }
+  }
+}

--- a/test-fixtures/clusterRole.yaml
+++ b/test-fixtures/clusterRole.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: monitoring
+aggregationRule:
+  clusterRoleSelectors:
+    - matchLabels:
+        rbac.example.com/aggregate-to-monitoring: "true"
+rules: [] # The control plane automatically fills in the rules


### PR DESCRIPTION
Fixes error:
```
3:43PM Warn | excluding attribute [kubernetes_cluster_role.aggregation_rule.cluster_role_selector] not found in Terraform schema  field=ClusterRole.AggregationRule.ClusterRoleSelectors name=monitoring type=kubernetes_cluster_role
resource "kubernetes_cluster_role" "monitoring" {
  metadata {
    name = "monitoring"
  }

  aggregation_rule {}
}
```

based on input YAML:
```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: monitoring
aggregationRule:
  clusterRoleSelectors:
    - matchLabels:
        rbac.example.com/aggregate-to-monitoring: "true"
rules: [] # The control plane automatically fills in the rules
```


After this fix, outputs as:
```hcl
resource "kubernetes_cluster_role" "monitoring" {
  metadata {
    name = "monitoring"
  }
  aggregation_rule {
    cluster_role_selectors {
      match_labels = { "rbac.example.com/aggregate-to-monitoring" = "true" }
    }
  }
}

```

Closes #81