### PR TITLE
Fix MatchExpression not found error

### DIFF
--- a/hcl_writer_test.go
+++ b/hcl_writer_test.go
@@ -143,6 +143,11 @@ func TestWriteObject(t *testing.T) {
 			"kubernetes_cluster_role",
 			0,
 		},
+		{
+			"issue-28",
+			"kubernetes_daemonset",
+			0,
+		},
 	}
 
 	for _, tt := range tests {

--- a/input_test.go
+++ b/input_test.go
@@ -18,12 +18,12 @@ func Test_readFilesInput(t *testing.T) {
 		{
 			"test-fixtures",
 			"test-fixtures",
-			22,
+			23,
 		},
 		{
 			"test-fixtures/",
 			"test-fixtures/",
-			22,
+			23,
 		},
 		{
 			"test-fixtures/nested/server-clusterrole.yaml",

--- a/pkg/tfkschema/name_mapper.go
+++ b/pkg/tfkschema/name_mapper.go
@@ -24,6 +24,7 @@ func init() {
 	inflection.AddSingular("imagePullSecrets", "imagePullSecrets")
 	inflection.AddSingular("capabilities", "capabilities")
 	inflection.AddSingular("ClusterRoleSelectors", "ClusterRoleSelectors")
+	inflection.AddSingular("MatchExpressions", "MatchExpressions")
 
 	inflection.AddUncountable("data")
 	inflection.AddUncountable("metadata")

--- a/test-fixtures/issue-28.tf.golden
+++ b/test-fixtures/issue-28.tf.golden
@@ -1,0 +1,132 @@
+resource "kubernetes_daemonset" "nvidia_driver_installer" {
+  metadata {
+    name      = "nvidia-driver-installer"
+    namespace = "kube-system"
+    labels    = { k8s-app = "nvidia-driver-installer" }
+  }
+  spec {
+    selector {
+      match_labels = { k8s-app = "nvidia-driver-installer" }
+    }
+    template {
+      metadata {
+        labels = { k8s-app = "nvidia-driver-installer", name = "nvidia-driver-installer" }
+      }
+      spec {
+        volume {
+          name = "dev"
+          host_path {
+            path = "/dev"
+          }
+        }
+        volume {
+          name = "vulkan-icd-mount"
+          host_path {
+            path = "/home/kubernetes/bin/nvidia/vulkan/icd.d"
+          }
+        }
+        volume {
+          name = "nvidia-install-dir-host"
+          host_path {
+            path = "/home/kubernetes/bin/nvidia"
+          }
+        }
+        volume {
+          name = "root-mount"
+          host_path {
+            path = "/"
+          }
+        }
+        volume {
+          name = "cos-tools"
+          host_path {
+            path = "/var/lib/cos-tools"
+          }
+        }
+        init_container {
+          name  = "nvidia-driver-installer"
+          image = "cos-nvidia-installer:fixed"
+          env {
+            name  = "NVIDIA_INSTALL_DIR_HOST"
+            value = "/home/kubernetes/bin/nvidia"
+          }
+          env {
+            name  = "NVIDIA_INSTALL_DIR_CONTAINER"
+            value = "/usr/local/nvidia"
+          }
+          env {
+            name  = "VULKAN_ICD_DIR_HOST"
+            value = "/home/kubernetes/bin/nvidia/vulkan/icd.d"
+          }
+          env {
+            name  = "VULKAN_ICD_DIR_CONTAINER"
+            value = "/etc/vulkan/icd.d"
+          }
+          env {
+            name  = "ROOT_MOUNT_DIR"
+            value = "/root"
+          }
+          env {
+            name  = "COS_TOOLS_DIR_HOST"
+            value = "/var/lib/cos-tools"
+          }
+          env {
+            name  = "COS_TOOLS_DIR_CONTAINER"
+            value = "/build/cos-tools"
+          }
+          resources {
+            requests = { cpu = "150m" }
+          }
+          volume_mount {
+            name       = "nvidia-install-dir-host"
+            mount_path = "/usr/local/nvidia"
+          }
+          volume_mount {
+            name       = "vulkan-icd-mount"
+            mount_path = "/etc/vulkan/icd.d"
+          }
+          volume_mount {
+            name       = "dev"
+            mount_path = "/dev"
+          }
+          volume_mount {
+            name       = "root-mount"
+            mount_path = "/root"
+          }
+          volume_mount {
+            name       = "cos-tools"
+            mount_path = "/build/cos-tools"
+          }
+          image_pull_policy = "Never"
+          security_context {
+            privileged = true
+          }
+        }
+        container {
+          name  = "pause"
+          image = "gcr.io/google-containers/pause:2.0"
+        }
+        host_network = true
+        host_pid     = true
+        affinity {
+          node_affinity {
+            required_during_scheduling_ignored_during_execution {
+              node_selector_term {
+                match_expressions {
+                  key      = "cloud.google.com/gke-accelerator"
+                  operator = "Exists"
+                }
+              }
+            }
+          }
+        }
+        toleration {
+          operator = "Exists"
+        }
+      }
+    }
+    strategy {
+      type = "RollingUpdate"
+    }
+  }
+}

--- a/test-fixtures/issue-28.yaml
+++ b/test-fixtures/issue-28.yaml
@@ -1,0 +1,106 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The Dockerfile and other source for this daemonset are in
+# https://github.com/GoogleCloudPlatform/cos-gpu-installer
+#
+# This is the same as ../../daemonset.yaml except that it assumes that the
+# docker image is present on the node instead of downloading from GCR. This
+# allows easier upgrades because GKE can preload the correct image on the
+# node and the daemonset can just use that image.
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nvidia-driver-installer
+  namespace: kube-system
+  labels:
+    k8s-app: nvidia-driver-installer
+spec:
+  selector:
+    matchLabels:
+      k8s-app: nvidia-driver-installer
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: nvidia-driver-installer
+        k8s-app: nvidia-driver-installer
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: cloud.google.com/gke-accelerator
+                operator: Exists
+      tolerations:
+      - operator: "Exists"
+      hostNetwork: true
+      hostPID: true
+      volumes:
+      - name: dev
+        hostPath:
+          path: /dev
+      - name: vulkan-icd-mount
+        hostPath:
+          path: /home/kubernetes/bin/nvidia/vulkan/icd.d
+      - name: nvidia-install-dir-host
+        hostPath:
+          path: /home/kubernetes/bin/nvidia
+      - name: root-mount
+        hostPath:
+          path: /
+      - name: cos-tools
+        hostPath:
+          path: /var/lib/cos-tools
+      initContainers:
+      - image: "cos-nvidia-installer:fixed"
+        imagePullPolicy: Never
+        name: nvidia-driver-installer
+        resources:
+          requests:
+            cpu: "0.15"
+        securityContext:
+          privileged: true
+        env:
+          - name: NVIDIA_INSTALL_DIR_HOST
+            value: /home/kubernetes/bin/nvidia
+          - name: NVIDIA_INSTALL_DIR_CONTAINER
+            value: /usr/local/nvidia
+          - name: VULKAN_ICD_DIR_HOST
+            value: /home/kubernetes/bin/nvidia/vulkan/icd.d
+          - name: VULKAN_ICD_DIR_CONTAINER
+            value: /etc/vulkan/icd.d
+          - name: ROOT_MOUNT_DIR
+            value: /root
+          - name: COS_TOOLS_DIR_HOST
+            value: /var/lib/cos-tools
+          - name: COS_TOOLS_DIR_CONTAINER
+            value: /build/cos-tools
+        volumeMounts:
+        - name: nvidia-install-dir-host
+          mountPath: /usr/local/nvidia
+        - name: vulkan-icd-mount
+          mountPath: /etc/vulkan/icd.d
+        - name: dev
+          mountPath: /dev
+        - name: root-mount
+          mountPath: /root
+        - name: cos-tools
+          mountPath: /build/cos-tools
+      containers:
+      - image: "gcr.io/google-containers/pause:2.0"
+        name: pause


### PR DESCRIPTION
Closes #28 
Closes #75 

*Example error fixed*
```
4:06PM Warn | excluding attribute [kubernetes_daemonset.spec.template.spec.affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_term.match_expression] not found in Terraform schema  field=DaemonSet.Spec.Template.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms.MatchExpressions name=nvidia_driver_installer type=kubernetes_daemonset
```