### PR TITLE
fix: dots are not allowed in Terraform names

### DIFF
--- a/pkg/tfkschema/name_mapper.go
+++ b/pkg/tfkschema/name_mapper.go
@@ -100,8 +100,9 @@ func NormalizeTerraformName(s string, toSingular bool, path string) string {
 	}
 	s = strcase.ToSnake(s)
 
-	// colons are not allowed by Terraform
+	// colons and dots are not allowed by Terraform
 	s = strings.ReplaceAll(s, ":", "_")
+	s = strings.ReplaceAll(s, ".", "_")
 
 	return s
 }

--- a/pkg/tfkschema/name_mapper_test.go
+++ b/pkg/tfkschema/name_mapper_test.go
@@ -252,6 +252,15 @@ func Test_NormalizeTerraformName(t *testing.T) {
 			},
 			"metallb_system_speaker",
 		},
+		{
+			"custom.metrics.k8s.io",
+			args{
+				"custom.metrics.k8s.io",
+				false,
+				"",
+			},
+			"custom_metrics_k_8_s_io",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Hi, thanks for this very useful tool!
Today I've tried to convert [Google's Custom Metrics Adapter](https://raw.githubusercontent.com/GoogleCloudPlatform/k8s-stackdriver/master/custom-metrics-stackdriver-adapter/deploy/production/adapter_new_resource_model.yaml) and I got invalid names in the final result.
Indeed, [dots are not valid in resource names](https://www.terraform.io/language/resources/syntax#resource-syntax) and their yaml file contains metadata names such as `v1beta1.custom.metrics.k8s.io`.

Before:
```tf
resource "kubernetes_api_service" "v_1_beta_1_.custom.metrics.k_8_s.io" {
  metadata {
    name = "v1beta1.custom.metrics.k8s.io"
  }
```

After:
```tf
resource "kubernetes_api_service" "v_1_beta_1__custom_metrics_k_8_s_io" {
  metadata {
    name = "v1beta1.custom.metrics.k8s.io"
  }
```